### PR TITLE
NONE - Make PhysX compatible with Clang-CL

### DIFF
--- a/physx/CMakeLists.txt
+++ b/physx/CMakeLists.txt
@@ -575,9 +575,11 @@ else ()
     )
 endif ()
 
-target_compile_options(PhysX PRIVATE
-        -Wno-invalid-offsetof
-)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(PhysX PRIVATE
+            -Wno-invalid-offsetof
+    )
+endif ()
 
 file(GLOB_RECURSE PHYSX_PUBLIC_HEADERS CONFIGURE_DEPENDS "include/*.hpp" "include/*.h")
 target_sources(

--- a/physx/include/foundation/PxAoS.h
+++ b/physx/include/foundation/PxAoS.h
@@ -29,10 +29,9 @@
 #ifndef PX_AOS_H
 #define PX_AOS_H
 
-
-#if PX_WINDOWS && !PX_NEON
+#if PX_WINDOWS && !PX_NEON && !__clang__
 #include "windows/PxWindowsAoS.h"
-#elif(PX_UNIX_FAMILY || PX_SWITCH)
+#elif (PX_UNIX_FAMILY || PX_SWITCH) || __clang__
 #include "unix/PxUnixAoS.h"
 #else
 #error "Platform not supported!"

--- a/physx/include/foundation/unix/sse2/PxUnixSse2AoS.h
+++ b/physx/include/foundation/unix/sse2/PxUnixSse2AoS.h
@@ -40,7 +40,7 @@ namespace physx
 namespace aos
 {
 
-#if PX_EMSCRIPTEN
+#if PX_EMSCRIPTEN || (defined(__clang__) && defined(_MSC_VER)) // workaround for clang-cl
 typedef int8_t   __int8_t;
 typedef int16_t  __int16_t;
 typedef int32_t  __int32_t;


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request.

Please write a bug report in the GitHub Issues if you Pull Request fixes a bug and add a link to the Issue.
-->

It took a few hours, but I found out how to make PhysX work with clang-cl in the MINIMAL amount of changes possible. I'm sort of proud of myself. This is much better than the previous changeset that I made to PhysX, and its compatible with the latest upgrade.

I also disabled my editor from ever formatting PhysX again so no more formatting issues